### PR TITLE
Set up git lfs to handle .mp4 files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.psd filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Validation OS SDK samples contain an mp4 file that exceeds GitHub's 100.00 MB size limit. 
To enable working with large files Git Large File Storage (LFS)  must be installed from https://git-lfs.com/ and the repo configuration must be changed to handle such files.